### PR TITLE
📌 22/10/24 Patching

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,9 +1,9 @@
 {
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      "version": "2.11.0",
-      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:503f23cd692325b3cbb8c20a0ecfabb3444b0c786b363e0c82572bd7d71dc099",
-      "integrity": "sha256:503f23cd692325b3cbb8c20a0ecfabb3444b0c786b363e0c82572bd7d71dc099"
+      "version": "2.12.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:5f3e2005aad161ce3ff7700b2603f11935348c039f9166960efd050d69cd3014",
+      "integrity": "sha256:5f3e2005aad161ce3ff7700b2603f11935348c039f9166960efd050d69cd3014"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/container-structure-test:1": {
       "version": "1.0.0",

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: Dependency Review
         id: dependency_review

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,11 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: Install cosign
         id: install_cosign
-        uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 # v3.6.0
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
       - name: Log in to GitHub Container Registry
         id: ghcr_login
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build and Push
         id: build_and_push
-        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6.7.0
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
@@ -57,7 +57,7 @@ jobs:
           output-file: "sbom.cyclonedx.json"
 
       - name: Attest
-        uses: actions/attest-build-provenance@6149ea5740be74af77f260b9db67e633f6b0a9a1 # v1.4.2
+        uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c # v1.4.3
         id: attest
         with:
           subject-name: ghcr.io/${{ github.repository }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: Build
         id: build

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,7 +30,10 @@ jobs:
 
       - name: Scan
         id: scan
-        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # v0.24.0
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
         with:
           image-ref: ghcr.io/${{ github.repository }}:${{ github.sha }}
           severity: HIGH,CRITICAL

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,11 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: Set Up Container Structure Test
         id: setup_container_structure_test
-        uses: ministryofjustice/github-actions/setup-container-structure-test@8e1bfc920f829ce408a5ef84118fbc160e559066 # v18.1.2
+        uses: ministryofjustice/github-actions/setup-container-structure-test@9f2e1064389dae6ca4098470b933da7042675e59 # v18.3.1
 
       - name: Test
         id: test

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,6 @@
+# Ubuntu
+CVE-2024-43882
+
 # Python
 ## setuptools
 CVE-2024-6345 # TODO: @jacobwoffenden - Figure out where this comes from and patch it
@@ -14,3 +17,4 @@ CVE-2024-0057
 # Go
 ## aws-sso
 CVE-2024-41110 # Vulnerability in github.com/docker/docker, but we don't run Docker on CDE
+CVE-2024-34156

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base@sha256:c5b1ca761b4a9db72506ed23831c525df52e5398177c041638d8f0b80c47356e
+FROM ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base@sha256:642f27835387423029b56cf298d671259d56f505157bcfae2d2a193993f4ca35
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,19 @@
-.PHONY: test build run
+.PHONY: build scan test run
 
 IMAGE_NAME ?= ghcr.io/ministryofjustice/analytical-platform-jupyterlab
 IMAGE_TAG  ?= local
+
+TRIVY_DB_REPOSITORY ?= public.ecr.aws/aquasecurity/trivy-db:2
+TRIVY_JAVA_DB_REPOSITORY ?= public.ecr.aws/aquasecurity/trivy-java-db:1
 
 run: build
 	docker run --rm -it --publish 8080:8080 $(IMAGE_NAME):$(IMAGE_TAG)
 
 test: build
 	container-structure-test test --platform linux/amd64 --config test/container-structure-test.yml --image $(IMAGE_NAME):$(IMAGE_TAG)
+
+scan: build
+	trivy image --platform linux/amd64 --severity HIGH,CRITICAL $(IMAGE_NAME):$(IMAGE_TAG)
 
 build:
 	@ARCH=`uname --machine`; \

--- a/src/opt/analytical-platform/requirements.txt
+++ b/src/opt/analytical-platform/requirements.txt
@@ -1,2 +1,2 @@
-jupyterlab==4.2.4
+jupyterlab==4.2.5
 jupyterlab-git==0.50.1

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -8,7 +8,7 @@ commandTests:
   - name: "jupyter"
     command: "jupyter"
     args: ["--version"]
-    expectedOutput: ["jupyterlab       : 4.2.4"]
+    expectedOutput: ["jupyterlab       : 4.2.5"]
 
 fileExistenceTests:
   - name: "/opt/analytical-platform/first-run-notice.txt"


### PR DESCRIPTION
This pull request:

- Updates CDE base to [1.5.0](https://github.com/ministryofjustice/analytical-platform-cloud-development-environment-base/releases/tag/1.5.0)
- Updates JupyterLab to 4.2.5
  - Resolves https://github.com/ministryofjustice/analytical-platform-jupyterlab/security/dependabot/1
- Updates GitHub Actions
  - Supersedes:
    - https://github.com/ministryofjustice/analytical-platform-jupyterlab/pull/31
    - https://github.com/ministryofjustice/analytical-platform-jupyterlab/pull/25
    - https://github.com/ministryofjustice/analytical-platform-jupyterlab/pull/24
    - https://github.com/ministryofjustice/analytical-platform-jupyterlab/pull/22
    - https://github.com/ministryofjustice/analytical-platform-jupyterlab/pull/19
    - https://github.com/ministryofjustice/analytical-platform-jupyterlab/pull/17
    - https://github.com/ministryofjustice/analytical-platform-jupyterlab/pull/13
- Updates Dev Container lockfile
- Aligns Trivy ignore with upstream
- Aligns Makefile with upstream
- Adds fix for using ECR in Trivy

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 