### PR TITLE
🔧  Update `trivyignore`

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,6 +1,8 @@
 # Ubuntu
 CVE-2024-43882
+CVE-2024-50264
 CVE-2024-53103
+CVE-2024-56658
 
 # Python
 ## setuptools
@@ -13,12 +15,10 @@ GHSA-94vc-p8w7-5p49
 ## We are running the latest dotnet-sdk from Ubuntu
 CVE-2024-0057
 CVE-2024-38095
-CVE-2024-0057
-CVE-2024-0057
-CVE-2024-38095
-CVE-2024-0057
 
 # Go
 ## aws-sso
 CVE-2024-41110 # Vulnerability in github.com/docker/docker, but we don't run Docker on CDE
 CVE-2024-34156
+CVE-2024-45337
+CVE-2024-45338


### PR DESCRIPTION
Updates to match CBDE image. Additionally adds CVE-2024-50264.