### PR TITLE
Update base image & bump jupyterlab

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base@sha256:08fb5935dbe1604a3c225782930c6c9a8384781916fde03731e89045691c44bc
+FROM ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base:1.43.6@sha256:004a086b51363a9e682ea32995242251265dd551ccbc591d8272eecb6110fa86
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \

--- a/src/opt/analytical-platform/requirements-jupyterlab.txt
+++ b/src/opt/analytical-platform/requirements-jupyterlab.txt
@@ -1,4 +1,4 @@
-jupyterlab==4.5.7
+jupyterlab==4.5.10
 jupyterlab-git==0.54.0
 notebook==7.5.6
 nbclassic==1.1.0

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -8,7 +8,7 @@ commandTests:
   - name: "jupyter"
     command: "jupyter"
     args: ["--version"]
-    expectedOutput: ["jupyterlab\\s+: 4.5.7"]
+    expectedOutput: ["jupyterlab\\s+: 4.5.10"]
 
 fileExistenceTests:
   - name: "/opt/analytical-platform/first-run-notice.txt"


### PR DESCRIPTION
This pull request updates the base Docker image and JupyterLab version to address dependency maintenance and keep the development environment up to date. The associated test has also been updated to reflect the new JupyterLab version.

Dependency and environment updates:

* Updated the base image in `Dockerfile` to use `analytical-platform-cloud-development-environment-base:1.43.6` with a new SHA256 digest.
* Upgraded `jupyterlab` to version 4.5.10 in `requirements-jupyterlab.txt` to ensure compatibility and receive the latest fixes.

Test updates:

* Modified the `container-structure-test.yml` to expect `jupyterlab` version 4.5.10 in the output, aligning tests with the updated dependency.