### PR TITLE
Split conda and pip requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ EOF
 # Base is used by users when installing with different versions of Python
 COPY --chown="${CONTAINER_USER}:${CONTAINER_GROUP}" --chmod=0644 src${ANALYTICAL_PLATFORM_DIRECTORY}/requirements-base.txt ${ANALYTICAL_PLATFORM_DIRECTORY}/requirements-base.txt
 COPY --chown="${CONTAINER_USER}:${CONTAINER_GROUP}" --chmod=0644 src${ANALYTICAL_PLATFORM_DIRECTORY}/requirements-scipy.txt ${ANALYTICAL_PLATFORM_DIRECTORY}/requirements-scipy.txt
+COPY --chown="${CONTAINER_USER}:${CONTAINER_GROUP}" --chmod=0644 src${ANALYTICAL_PLATFORM_DIRECTORY}/environment-scipy.yml ${ANALYTICAL_PLATFORM_DIRECTORY}/environment-scipy.yml
 
 USER ${CONTAINER_USER}
 WORKDIR /home/${CONTAINER_USER}

--- a/src/opt/analytical-platform/environment-scipy.yml
+++ b/src/opt/analytical-platform/environment-scipy.yml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - blas=*=openblas
+  - matplotlib-base=3.9.2
+  - pytables=3.10.1

--- a/src/opt/analytical-platform/requirements-scipy.txt
+++ b/src/opt/analytical-platform/requirements-scipy.txt
@@ -5,21 +5,19 @@ beautifulsoup4==4.12.3
 bokeh==3.6.0
 bottleneck==1.3.7
 cloudpickle==3.0.0
-# Install separately via conda: conda install -c conda-forge "blas=*=openblas"
 cython==3.0.11
 dask==2024.8.2
 dill==0.3.8
 h5py==3.12.1
 ipympl==0.9.4
 ipywidgets==8.1.2
-matplotlib-base==3.9.2
+matplotlib==3.9.2
 numba==0.60.0
 numexpr==2.10.1
 openpyxl==3.1.5
 pandas==2.2.2
 patsy==0.5.6
 protobuf==4.25.3
-pytables==3.10.1
 scikit-image==0.24.0
 scikit-learn==1.5.1
 scipy==1.13.1
@@ -27,5 +25,6 @@ seaborn==0.13.2
 sqlalchemy==2.0.34
 statsmodels==0.14.2
 sympy==1.13.2
+tables==3.10.1
 widgetsnbextension==4.0.10
 xlrd==2.0.1

--- a/src/opt/analytical-platform/requirements-scipy.txt
+++ b/src/opt/analytical-platform/requirements-scipy.txt
@@ -5,7 +5,7 @@ beautifulsoup4==4.12.3
 bokeh==3.6.0
 bottleneck==1.3.7
 cloudpickle==3.0.0
-conda-forge::blas=*=openblas
+# Install separately via conda: conda install -c conda-forge "blas=*=openblas"
 cython==3.0.11
 dask==2024.8.2
 dill==0.3.8


### PR DESCRIPTION
This pull request updates the environment and requirements configuration aligning the conda environment and pip requirements for the SciPy stack, updating how certain packages are installed, and ensuring consistency between the two files.

**Dependency management and alignment:**

* Added a new conda environment file `environment-scipy.yml` with explicit channels (`conda-forge`, `defaults`) and dependencies (`blas=*=openblas`, `matplotlib-base=3.9.2`, `pytables=3.10.1`) to standardize environment setup.
* Removed `conda-forge::blas=*=openblas`, `matplotlib-base==3.9.2`, and `pytables==3.10.1` from `requirements-scipy.txt` and replaced with `matplotlib==3.9.2` and `tables==3.10.1` for better compatibility with pip installation.

These changes help ensure that environment setup is more robust and compatible across different installation methods.